### PR TITLE
Fix MacOS default pred settings

### DIFF
--- a/src/main/java/qupath/ext/biop/spotiflow/Spotiflow.java
+++ b/src/main/java/qupath/ext/biop/spotiflow/Spotiflow.java
@@ -78,7 +78,7 @@ public class Spotiflow {
     protected SpotiflowSetup spotiflowSetup = SpotiflowSetup.getInstance();
     protected LinkedHashMap<String, String> parameters;
     protected boolean savePredictionImages;
-    protected boolean useGPU;
+    protected boolean disableGPU;
     protected boolean process3d;
     protected double probabilityThreshold;
     protected double minDistance;
@@ -484,10 +484,10 @@ public class Spotiflow {
         }
 
         spotiflowArguments.add("--device");
-        if(this.useGPU){
-            spotiflowArguments.add("cuda");
-        } else {
+        if(this.disableGPU){
             spotiflowArguments.add("cpu");
+        } else {
+            spotiflowArguments.add("auto");
         }
 
         this.parameters.forEach((parameter, value) -> {

--- a/src/main/java/qupath/ext/biop/spotiflow/SpotiflowBuilder.java
+++ b/src/main/java/qupath/ext/biop/spotiflow/SpotiflowBuilder.java
@@ -53,7 +53,7 @@ public class SpotiflowBuilder {
     private File trainingOutputDir = null;
     private Map<String, Integer> channels = new HashMap<>();
     private boolean savePredictionImages = true;
-    private boolean useGPU = true;
+    private boolean disableGPU = false;
     private boolean process3d = false;
     private String doSubpixel = "None";
     private double probabilityThreshold = -1;
@@ -197,13 +197,13 @@ public class SpotiflowBuilder {
     }
 
     /**
-     * Enable CPU / GPU usage
+     * Forces using CPU instead of GPU
      *
-     * @param useGPU  override useGPU
+     * @param disableGPU  override disableGPU
      * @return this builder
      */
-    public SpotiflowBuilder useGPU(boolean useGPU) {
-        this.useGPU = useGPU;
+    public SpotiflowBuilder disableGPU(boolean disableGPU) {
+        this.disableGPU = disableGPU;
         return this;
     }
 
@@ -309,7 +309,7 @@ public class SpotiflowBuilder {
         spotiflow.spotiflowSetup = this.spotiflowSetup;
         spotiflow.parameters = this.spotiflowParameters;
         spotiflow.savePredictionImages = this.savePredictionImages;
-        spotiflow.useGPU = this.useGPU;
+        spotiflow.disableGPU = this.disableGPU;
         spotiflow.probabilityThreshold = this.probabilityThreshold;
         spotiflow.minDistance = this.minDistance;
         spotiflow.channels = this.channels;

--- a/src/main/resources/scripts/Spotiflow_detection_template.groovy
+++ b/src/main/resources/scripts/Spotiflow_detection_template.groovy
@@ -26,7 +26,7 @@ def spotiflow = Spotiflow.builder()
 //        .setPretrainedModelName("smfish_3d")                 // OPTIONAL : Default is 'general'
 //        .setMinDistance(2)                                   // OPTIONAL : Positive value
 //        .setProbabilityThreshold(0.2)                        // OPTIONAL : Positive value
-//        .useGPU(false)                                       // OPTIONAL : false to use CPU ; default is true
+//        .disableGPU(true)                                    // OPTIONAL : true to force CPU ; default is false (use GPU if available)
 //        .addParameter("key","value")                         // OPTIONAL : Add more parameter, base on the available ones
 //        .process3d(true)                                     // OPTIONAL : process the entire zstack ; default false
 //        .doSubpixel(true)                                    // OPTIONAL : true to get subpixel resolution ; false to not. Default: let spotiflow choose


### PR DESCRIPTION
Hi @Rdornier,

Thanks a lot for building this! I saw in the release notes that you did not test it in MacOS, so I decided to do it myself :)
Turns out that in its default settings, the prediction didn't work straightaway. In the released code, the device is set to CUDA if the flag `useGPU` is passed. This makes Spotiflow try to force using on a CUDA device even if not present hardware-wise, which raises an error. For a Mac w/ Apple Silicon, disabling the GPU worked, although it runs on CPU instead of on MPS acceleration, which is suboptimal.

In the Spotiflow CLI, if a device is not passed/is `auto`, then Spotiflow decides which device to run on, prioritizing CUDA/MPS if present on CPU. I think it is a sensible default behaviour. I'm proposing in this PR to change the `useGPU` to `disableGPU` if someone does want to force prediction on CPU. This makes the extension to by default run on CUDA/MPS if present, so it should work on all platforms.

Leaving it on draft for now. Let me know what you think!

